### PR TITLE
Fixed clippy, added additional lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,12 +1,3 @@
-[root]
-name = "sniff"
-version = "0.1.0"
-dependencies = [
- "ipnetwork 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pnet_datalink 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "aho-corasick"
 version = "0.6.3"
@@ -165,6 +156,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sniff"
+version = "0.1.0"
+dependencies = [
+ "ipnetwork 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pnet_datalink 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "syntex"


### PR DESCRIPTION
Some fixes.

- Added more strict rules for clippy (more lints). These are based on http://blog.faraday.io/good-strict-default-warnings-for-rust-code/ and I usually add them to any project
- Use `expect("ERROR!!!")` instead of `writeln!("ERROR!!!").unwrap(); std::process::exit(1);`. The correct exit code would be 22 (missing argument), but usually just using "expect()" is good enough, especially if you want a stack trace
- I use the `something.is_none() { return; }; let something = something.unwrap();` pattern. This is a common pattern to avoid an extra level of indentation, but it's not the cleanest way. The currently best way to handle it is by using the [inner](https://github.com/diwic/inner-rs) crate (which just puts this pattern into a macro).
- `println!()` takes displayable items by reference, not by value. A `to_string()` (cloning the value and putting it in a string) is not needed.
- `.filter("x").next()` is better expressed as `.find("x")`. This was caught by clippy.
- Removed commented-out lines
- `match value { &Something => ... }` should be replaced with `match *value { Something => ... }`. Borrowing with enums is a bit messy.

The unwrapping of inner values is a stylistic choice, however, I personally hate huge if-blocks with a small else-block at the end - I'd rather use early return here.